### PR TITLE
Add splash screen with Netflix logo and branding

### DIFF
--- a/NetflixClone/Assets.xcassets/NetflixLogo.imageset/Contents.json
+++ b/NetflixClone/Assets.xcassets/NetflixLogo.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/NetflixClone/Assets.xcassets/backgroundColor.colorset/Contents.json
+++ b/NetflixClone/Assets.xcassets/backgroundColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/NetflixClone/Assets.xcassets/netflixRed.colorset/Contents.json
+++ b/NetflixClone/Assets.xcassets/netflixRed.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.078",
+          "green" : "0.035",
+          "red" : "0.898"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/NetflixClone/Base.lproj/LaunchScreen.storyboard
+++ b/NetflixClone/Base.lproj/LaunchScreen.storyboard
@@ -13,7 +13,20 @@
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="NetflixLogo" translatesAutoresizingMaskIntoConstraints="NO" id="Cbd-Vy-l6P">
+                                <rect key="frame" x="87.5" y="233.5" width="200" height="200"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="200" id="8tQ-j1-NNp"/>
+                                    <constraint firstAttribute="height" constant="200" id="dcx-kf-f65"/>
+                                </constraints>
+                            </imageView>
+                        </subviews>
+                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="Cbd-Vy-l6P" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="2Ex-fp-X3O"/>
+                            <constraint firstItem="Cbd-Vy-l6P" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="OGq-MF-WxW"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                 </viewController>
@@ -22,4 +35,7 @@
             <point key="canvasLocation" x="53" y="375"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="NetflixLogo" width="200" height="200"/>
+    </resources>
 </document>

--- a/netflix-logo.svg
+++ b/netflix-logo.svg
@@ -1,0 +1,4 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="200" height="200" fill="black"/>
+  <path d="M59 40v120h22V84l40 76h20V40h-22v76L79 40z" fill="#E50914"/>
+</svg>


### PR DESCRIPTION
This PR adds a splash screen to the Netflix Clone app with the following changes:

- Created Netflix logo SVG
- Added color assets for Netflix branding
- Modified LaunchScreen.storyboard to display logo
- Implemented splash screen with proper styling and layout

Fixes #1

Generated with [Claude Code](https://claude.ai/code)